### PR TITLE
Use neutral (untranslated) prefix for amendments.

### DIFF
--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -114,7 +114,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='motions_amendments_prefix',
-        default_value='A',
+        default_value='-',
         label='Prefix for the identifier for amendments',
         weight=340,
         group='Motions',

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -1664,8 +1664,6 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
         gettext('Amendments');
         gettext('Activate amendments');
         gettext('Prefix for the identifier for amendments');
-        /// Prefix for the identifier for amendments
-        gettext('A');
         gettext('Apply title and text for new amendments');
 
         // subgroup Suppoerters


### PR DESCRIPTION
Reason: Server cannot use the on client-side translated prefix string.